### PR TITLE
Enable chunked inference on GPU

### DIFF
--- a/protein_learning/models/inference_utils.py
+++ b/protein_learning/models/inference_utils.py
@@ -382,7 +382,7 @@ class Inference:
             if len(model_input.decoy) <= chunk_size:
                 model_output = model(model_input, use_cycles=1)
             else:
-                model_output = chunk_inference(model, model_input, max_len=chunk_size)
+                model_output = chunk_inference(model, model_input, max_len=chunk_size, device=self.device)
             if format:
                 return format_prediction(model, model_input, model_output)
             return model_output


### PR DESCRIPTION
Running chunked inference on the GPU would result in a device mismatch because `chunk_inference` has the default argument `device='cpu'`. This PR overwrites that default by specifying whatever device `Inference` is on.